### PR TITLE
Update Onclicka ad script and banner IDs

### DIFF
--- a/IPL-3.0/templates/ball_by_ball.html
+++ b/IPL-3.0/templates/ball_by_ball.html
@@ -51,11 +51,11 @@
         .team-display .score-details {font-size: 1.1em; margin-left:10px;}
 
     </style>
-<script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="337943"></script>
+<script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="337947"></script>
 </head>
 <body>
     <div class="container">
-        <div data-banner-id="6077667"></div>
+        <div data-banner-id="6077670"></div>
         <h1>Live Cricket Simulation</h1>
         <p style="text-align:center;"><a href="{{ url_for('index') }}">New Match / Back to Team Selection</a></p>
 

--- a/IPL-3.0/templates/index.html
+++ b/IPL-3.0/templates/index.html
@@ -423,12 +423,12 @@
             background-color: var(--button-hover-bg);
        }
     </style>
-<script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="337943"></script>
+<script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="337947"></script>
 </head>
 <body>
     <button id="themeToggleBtn" style="position: fixed; top: 20px; right: 20px; padding: 8px 12px; z-index: 1001; cursor: pointer;">Toggle Theme</button>
     <div class="container">
-        <div data-banner-id="6077667"></div>
+        <div data-banner-id="6077670"></div>
         <h2>Cricket Scorecard Generator</h2>
 
         {% if not scorecard_data %}


### PR DESCRIPTION
Replaces the existing Onclicka ad script and banner ad div with new IDs you provided.

The `data-admpid` in the script is updated from `337943` to `337947`. The `data-banner-id` in the div is updated from `6077667` to `6077670`.

These changes are applied to:
- `IPL-3.0/templates/ball_by_ball.html`
- `IPL-3.0/templates/index.html`

This is to ensure the correct and latest ad units are used for displaying banner advertisements.