### PR TITLE
Refactor ad placements and add new ad slots

### DIFF
--- a/IPL-3.0/templates/ball_by_ball.html
+++ b/IPL-3.0/templates/ball_by_ball.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ball-by-Ball Simulation</title>
     <style>
-        body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; margin: 0; background-color: #1e1e1e; color: #fff; display: flex; justify-content: center; align-items: center; min-height: 100vh; padding: 20px; box-sizing: border-box; }
+        body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; margin: 0; background-color: #1e1e1e; color: #fff; display: flex; justify-content: center; align-items: center; min-height: 100vh; padding: 20px; box-sizing: border-box; position: relative; }
         .container { width: 100%; max-width: 960px; background: #2c2c2c; padding: 20px; border-radius: 10px; box-shadow: 0 0 20px rgba(0,0,0,0.5); }
 
         h1, h2, h3 { text-align: center; color: #ffcc00; }
@@ -50,14 +50,23 @@
         .team-display .name {font-size: 1.2em; font-weight:bold;}
         .team-display .score-details {font-size: 1.1em; margin-left:10px;}
 
+        .ad-container-left { position: fixed; left: 10px; top: 100px; width: 160px; /* Example width */ height: 600px; /* Example height */ z-index: 999; }
+        .ad-container-right { position: fixed; right: 10px; top: 100px; width: 160px; /* Example width */ height: 600px; /* Example height */ z-index: 999; }
+
     </style>
-<script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="337947"></script>
+<script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="337971"></script>
+<script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="338039"></script>
 </head>
 <body>
+<div class="ad-container-left">
+    <div data-banner-id="6077680"></div>
+</div>
+<div class="ad-container-right">
+    <div data-banner-id="6077680"></div>
+</div>
     <div class="container">
-        <div data-banner-id="6077670"></div>
         <h1>Live Cricket Simulation</h1>
-        <p style="text-align:center;"><a href="{{ url_for('index') }}">New Match / Back to Team Selection</a></p>
+        <p style="text-align:center;"><a id="backToIndexLink" href="{{ url_for('index') }}">New Match / Back to Team Selection</a></p>
 
         <div id="tossDisplay" class="section"></div>
 
@@ -156,6 +165,7 @@
 
         let autoPlayInterval = null;
         let currentInningsLogNumber = 0;
+        let popUnderAdTriggeredOnGameOver = false;
 
         function formatOver(legalBalls) {
             if (legalBalls === undefined || legalBalls === null || legalBalls < 0) return "0.0";
@@ -259,6 +269,23 @@
                 startAutoPlayBtn.disabled = true;
                 pauseAutoPlayBtn.classList.add('hidden');
                 if (autoPlayInterval) clearInterval(autoPlayInterval);
+
+                if (!popUnderAdTriggeredOnGameOver) {
+                    popUnderAdTriggeredOnGameOver = true; // Set flag
+                    console.log("Pop-under ad triggered for admpid 338039 due to game over.");
+
+                    // Dynamically create and append the pop-under ad script
+                    var script = document.createElement('script');
+                    script.async = true;
+                    script.src = "https://js.onclckmn.com/static/onclicka.js";
+                    script.setAttribute('data-admpid', '338039');
+                    // Remove existing if any, then append
+                    const existingScript = document.querySelector('script[data-admpid="338039"]');
+                    if(existingScript && existingScript.parentNode === document.body) {
+                        document.body.removeChild(existingScript);
+                    }
+                    document.body.appendChild(script);
+                }
             } else {
                 simulateNextBallBtn.disabled = false;
                 startAutoPlayBtn.disabled = false;
@@ -267,8 +294,35 @@
         }
 
         const initialGameState = {{ game_state | tojson }};
+        popUnderAdTriggeredOnGameOver = false; // Reset flag on game state initialization
         currentInningsLogNumber = initialGameState.current_innings_num || 1; // Ensure it's at least 1
         updateUI(initialGameState, null);
+
+        const backToIndexLink = document.getElementById('backToIndexLink');
+        if (backToIndexLink) {
+            backToIndexLink.addEventListener('click', function(event) {
+                event.preventDefault(); // Prevent default navigation
+                console.log("Pop-under ad triggered for admpid 338039 due to link click.");
+
+                // Dynamically create and append the pop-under ad script
+                var script = document.createElement('script');
+                script.async = true;
+                script.src = "https://js.onclckmn.com/static/onclicka.js";
+                script.setAttribute('data-admpid', '338039');
+                // Remove existing if any, then append
+                const existingScript = document.querySelector('script[data-admpid="338039"]');
+                if(existingScript && existingScript.parentNode === document.body) {
+                    document.body.removeChild(existingScript);
+                }
+                document.body.appendChild(script);
+
+                // Proceed with navigation after a short delay
+                const href = this.href;
+                setTimeout(function() {
+                    window.location.href = href;
+                }, 300); // 0.3 second delay
+            });
+        }
 
         async function handleSimulateNextBall() {
             simulateNextBallBtn.disabled = true;

--- a/IPL-3.0/templates/index.html
+++ b/IPL-3.0/templates/index.html
@@ -116,7 +116,10 @@
             padding-top: 20px;
             padding-bottom: 20px;
             color: var(--text-color);
+            position: relative;
         }
+        .ad-container-left { position: fixed; left: 10px; top: 100px; width: 160px; /* Example width, adjust if known */ height: 600px; /* Example height, adjust if known */ z-index: 999; }
+        .ad-container-right { position: fixed; right: 10px; top: 100px; width: 160px; /* Example width, adjust if known */ height: 600px; /* Example height, adjust if known */ z-index: 999; }
         .container {
             max-width: 800px;
             margin: auto;
@@ -423,12 +426,18 @@
             background-color: var(--button-hover-bg);
        }
     </style>
-<script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="337947"></script>
+<script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="337971"></script>
+<script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="337957"></script>
 </head>
 <body>
+<div class="ad-container-left">
+    <div data-banner-id="6077680"></div>
+</div>
+<div class="ad-container-right">
+    <div data-banner-id="6077680"></div>
+</div>
     <button id="themeToggleBtn" style="position: fixed; top: 20px; right: 20px; padding: 8px 12px; z-index: 1001; cursor: pointer;">Toggle Theme</button>
     <div class="container">
-        <div data-banner-id="6077670"></div>
         <h2>Cricket Scorecard Generator</h2>
 
         {% if not scorecard_data %}
@@ -690,11 +699,67 @@
                 const scorecardForm = document.getElementById('scorecardForm');
                 if (scorecardForm) {
                     scorecardForm.addEventListener('submit', function(event) {
+                        const submitter = event.submitter; // Get the button that triggered the submit
+
+                        // Original validation
                         if (!selectedTeam1Input.value || !selectedTeam2Input.value) {
-                            event.preventDefault(); alert('Please select two teams to generate the scorecard.');
-                        } else if (selectedTeam1Input.value === selectedTeam2Input.value) {
-                            event.preventDefault(); alert('Please select two different teams.');
+                            event.preventDefault();
+                            alert('Please select two teams to generate the scorecard.');
+                            return;
                         }
+                        if (selectedTeam1Input.value === selectedTeam2Input.value) {
+                            event.preventDefault();
+                            alert('Please select two different teams.');
+                            return;
+                        }
+
+                        // Check if the submitter is one of the simulation buttons
+                        if (submitter && (submitter.id === 'directSimButton' || submitter.id === 'ballByBallSimButton')) {
+                            event.preventDefault(); // Prevent the default form submission
+
+                            console.log("Video ad triggered for admpid 337957 by button: " + submitter.id);
+
+                            // Dynamically create and append the video ad script
+                            var script = document.createElement('script');
+                            script.async = true;
+                            script.src = "https://js.onclckmn.com/static/onclicka.js";
+                            script.setAttribute('data-admpid', '337957');
+                            // Ensure script is removed if it exists to avoid multiple instances from multiple clicks if user doesn't navigate
+                            const existingScript = document.querySelector('script[data-admpid="337957"]');
+                            if(existingScript && existingScript.parentNode === document.body) {
+                                document.body.removeChild(existingScript);
+                            }
+                            document.body.appendChild(script);
+
+                            // Add a one-time event listener for the script load or error
+                            let scriptLoaded = false;
+                            script.onload = () => {
+                                console.log("Video ad script loaded.");
+                                scriptLoaded = true;
+                                // Some ad systems might offer a callback when ad is ready/closed. This is a guess.
+                                // If ad script itself blocks/redirects, this might not be needed.
+                                // For now, we rely on the timeout.
+                            };
+                            script.onerror = () => {
+                                console.error("Video ad script failed to load.");
+                                scriptLoaded = true; // Treat as loaded to allow submission
+                                 // Submit the form even if ad fails to load to not break functionality
+                                console.log("Submitting form after script error.");
+                                scorecardForm.submit();
+                            };
+
+                            // Submit the form after a delay
+                            // Increased delay slightly to give ad more time, assuming it's visual
+                            setTimeout(function() {
+                                if (!scriptLoaded) {
+                                     console.warn("Ad script load status unknown after timeout, submitting form.");
+                                }
+                                console.log("Submitting form after video ad delay for button: " + submitter.id);
+                                scorecardForm.submit();
+                            }, 1000); // 1 second delay
+                        }
+                        // If not submitted by these buttons, the original (if any) implicit submit behavior occurs
+                        // as event.preventDefault() was not called for them here.
                     });
                 }
             }


### PR DESCRIPTION
This commit addresses issue # (if applicable, otherwise remove this line).

Key changes:

1.  **Removed Existing Ads:**
    *   I removed the old banner ad (script data-admpid="337947", div data-banner-id="6077670") from `index.html` and `ball_by_ball.html`.

2.  **New Banner Ads (Side Banners):**
    *   I added a new banner ad script (data-admpid="337971") and divs (data-banner-id="6077680") to `index.html` and `ball_by_ball.html`.
    *   These banners are placed in new `div.ad-container-left` and `div.ad-container-right` elements.
    *   CSS has been added to position these containers as fixed elements on the left and right sides of the main content.

3.  **Video Ad Implementation:**
    *   I added a video ad script (data-admpid="337957") to `index.html`.
    *   I modified the JavaScript event listener for the main simulation buttons ("Direct Scorecard", "Ball-by-Ball Simulation").
    *   When these buttons are clicked, the video ad script is dynamically loaded/re-triggered before the main form submission occurs (with a 1-second delay).

4.  **Pop-under Ad Implementation:**
    *   I added a pop-under ad script (data-admpid="338039") to `ball_by_ball.html`.
    *   The ad is triggered under two conditions:
        *   When the "New Match / Back to Team Selection" link is clicked (with a 300ms delay before navigation).
        *   When the game ends (`gameState.game_over` is true), ensuring it only fires once per game session.
    *   Logic involves dynamic loading/re-triggering of the ad script.

All ad script additions also include the main script tag in the `<head>` of the respective HTML files for initial load, while event-triggered ads also use dynamic script appending to attempt re-activation.