### PR TITLE
Fix: Ensure simulation_type is passed when video ad is triggered

### DIFF
--- a/IPL-3.0/templates/index.html
+++ b/IPL-3.0/templates/index.html
@@ -743,10 +743,31 @@
                             script.onerror = () => {
                                 console.error("Video ad script failed to load.");
                                 scriptLoaded = true; // Treat as loaded to allow submission
-                                 // Submit the form even if ad fails to load to not break functionality
-                                console.log("Submitting form after script error.");
+                                console.log("Submitting form after script error (inside onerror).");
+                                // Ensure simulation_type is set before this submission path too
+                                const simulationTypeOnError = submitter.value;
+                                let simTypeInputOnError = scorecardForm.querySelector('input[name="simulation_type"][type="hidden"]');
+                                if (!simTypeInputOnError) {
+                                    simTypeInputOnError = document.createElement('input');
+                                    simTypeInputOnError.type = 'hidden';
+                                    simTypeInputOnError.name = 'simulation_type';
+                                    scorecardForm.appendChild(simTypeInputOnError);
+                                }
+                                simTypeInputOnError.value = simulationTypeOnError;
                                 scorecardForm.submit();
                             };
+
+                            // Ensure simulation_type is correctly passed
+                            const simulationType = submitter.value;
+                            let simTypeInput = scorecardForm.querySelector('input[name="simulation_type"][type="hidden"]');
+                            if (!simTypeInput) {
+                                simTypeInput = document.createElement('input');
+                                simTypeInput.type = 'hidden';
+                                simTypeInput.name = 'simulation_type';
+                                scorecardForm.appendChild(simTypeInput);
+                            }
+                            simTypeInput.value = simulationType;
+                            console.log("Set simulation_type to: " + simulationType + " before setTimeout");
 
                             // Submit the form after a delay
                             // Increased delay slightly to give ad more time, assuming it's visual
@@ -754,7 +775,8 @@
                                 if (!scriptLoaded) {
                                      console.warn("Ad script load status unknown after timeout, submitting form.");
                                 }
-                                console.log("Submitting form after video ad delay for button: " + submitter.id);
+                                console.log("Submitting form after video ad delay for button: " + submitter.id + " with type: " + simulationType);
+                                // The hidden input is already set, so just submit.
                                 scorecardForm.submit();
                             }, 1000); // 1 second delay
                         }


### PR DESCRIPTION
This commit fixes a regression where the `simulation_type` was not being correctly submitted to the backend when a video ad was displayed after clicking the 'Direct Scorecard' or 'Ball-by-Ball Simulation' buttons on the index page.

The previous implementation used `event.preventDefault()` and then programmatically called `scorecardForm.submit()`. This process did not include the value of the clicked submit button.

The fix involves:
- Retrieving the `value` from the `event.submitter` (the clicked button).
- Dynamically creating or updating a hidden input field (`<input type="hidden" name="simulation_type">`) within the form.
- Setting this hidden input's value to the `simulation_type` obtained from the clicked button. This ensures that when `scorecardForm.submit()` is called after the ad display logic, the `simulation_type` is correctly included in the submitted form data, resolving the "Please select a simulation type" error. The logic has been updated in the main `setTimeout` submission path and also in the `script.onerror` fallback submission path for the video ad script.