### PR TITLE
Add further in-page and banner ad placements

### DIFF
--- a/IPL-3.0/templates/ball_by_ball.html
+++ b/IPL-3.0/templates/ball_by_ball.html
@@ -58,6 +58,8 @@
 <script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="338039"></script>
 <script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="338041"></script>
 <script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="338043"></script>
+<script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="338049"></script>
+<script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="338051"></script>
 </head>
 <body>
 <div class="ad-container-left">
@@ -68,6 +70,7 @@
 </div>
     <div class="container">
         <h1>Live Cricket Simulation</h1>
+<div data-banner-id="6077709" style="margin: 10px 0; text-align: center;"></div>
         <p style="text-align:center;"><a id="backToIndexLink" href="{{ url_for('index') }}">New Match / Back to Team Selection</a></p>
 
 <div data-banner-id="6077700" style="margin-top: 15px; margin-bottom: 15px; text-align: center;"></div>
@@ -96,6 +99,7 @@
                 <p><strong>Target:</strong> <span id="targetScore">0</span></p>
                 <p><strong>Needed:</strong> <span id="runsNeeded">0</span> runs from <span id="ballsRemaining">0</span> balls</p>
             </div>
+<div data-banner-id="6077709" style="margin: 10px 0; text-align: center;"></div>
         </div>
 
 <div data-banner-id="6077700" style="margin-top: 15px; margin-bottom: 15px; text-align: center;"></div>
@@ -104,6 +108,7 @@
             <p>On Strike: <span id="batsman-onstrike" class="player-highlight">N/A</span></p>
             <p>Non-Striker: <span id="batsman-nonstrike">N/A</span></p>
             <p>Current Bowler: <span id="current-bowler">N/A</span></p>
+<div data-banner-id="6077709" style="margin: 10px 0; text-align: center;"></div>
         </div>
 
         <div id="winMessageContainer" class="win-message hidden"></div>
@@ -132,6 +137,7 @@
         <div class="section full-log-box">
             <h3>Full Innings Log</h3>
             <div id="full-innings-log"></div>
+<div data-banner-id="6077709" style="margin: 10px 0; text-align: center;"></div>
         </div>
 <div data-banner-id="6077700" style="margin-top: 15px; margin-bottom: 15px; text-align: center;"></div>
     </div>

--- a/IPL-3.0/templates/index.html
+++ b/IPL-3.0/templates/index.html
@@ -429,6 +429,8 @@
 <script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="337971"></script>
 <script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="337957"></script>
 <script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="338043"></script>
+<script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="338049"></script>
+<script async src="https://js.onclckmn.com/static/onclicka.js" data-admpid="338051"></script>
 </head>
 <body>
 <div class="ad-container-left">
@@ -444,6 +446,7 @@
         {% if not scorecard_data %}
             <div class="team-selection">
                 <h3>Select Teams (Click to Select)</h3>
+<div data-banner-id="6077709" style="margin: 10px 0; text-align: center;"></div>
                 <form id="scorecardForm" action="{{ url_for('generate_scorecard') }}" method="post">
                     <input type="hidden" name="selectedTeam1" id="selectedTeam1">
                     <input type="hidden" name="selectedTeam2" id="selectedTeam2">
@@ -462,7 +465,7 @@
                         </div>
                         {% endfor %}
                     </div>
-
+<div data-banner-id="6077709" style="margin: 10px 0; text-align: center;"></div>
                     <div class="simulation-options" style="text-align: center; margin-top: 20px; display: none;">
                         <button type="submit" name="simulation_type" value="direct" id="directSimButton" class="sim-button">Direct Scorecard</button>
                         <button type="submit" name="simulation_type" value="ball_by_ball" id="ballByBallSimButton" class="sim-button">Ball-by-Ball Simulation</button>
@@ -486,12 +489,14 @@
         {% if scorecard_data %}
         <div class="scorecard-section">
             <h3>{{ scorecard_data.match_teams_title }}</h3>
+<div data-banner-id="6077709" style="margin: 10px 0; text-align: center;"></div>
             {% if scorecard_data.tossMsg %}
             <div class="match-summary toss-summary"><h4>Toss</h4><p>{{ scorecard_data.tossMsg }}</p></div> <!-- toss-summary class added to allow specific styling if needed -->
             {% endif %}
             {% if scorecard_data.innings1BatTeam %}
             <h4>Innings 1: {{ scorecard_data.innings1BatTeam.upper() }}</h4>
             <table><thead><tr><th>Player</th><th>Runs</th><th>Balls</th><th>SR</th><th>How Out</th></tr></thead><tbody>{% for player, stats in scorecard_data.innings1Battracker.items() %}<tr><td>{{ player }}</td><td>{{ stats.runs }}</td><td>{{ stats.balls }}</td><td>{{ '%.2f'|format((stats.runs / stats.balls * 100) if stats.balls > 0 else 0) }}</td><td>{{ stats.how_out }}</td></tr>{% endfor %}</tbody></table>
+<div data-banner-id="6077709" style="margin: 10px 0; text-align: center;"></div>
             <p><strong>Total: {{ scorecard_data.innings1Runs }}/{{ scorecard_data.innings1Wickets }} ({{ (scorecard_data.innings1Balls // 6) if scorecard_data.innings1Balls else 0 }}.{{ scorecard_data.innings1Balls % 6 if scorecard_data.innings1Balls else 0 }} Overs)</strong></p>
             <h5>Bowling: {{ scorecard_data.innings2BatTeam.upper() }}</h5>
             <table><thead><tr><th>Player</th><th>Overs</th><th>Runs</th><th>Wickets</th><th>Economy</th></tr></thead><tbody>{% for player, stats in scorecard_data.innings1Bowltracker.items() %}<tr><td>{{ player }}</td><td>{{ (stats.balls // 6) if stats.balls else 0 }}.{{ stats.balls % 6 if stats.balls else 0 }}</td><td>{{ stats.runs }}</td><td>{{ stats.wickets }}</td><td>{{ '%.2f'|format((stats.runs / (stats.balls / 6)) if stats.balls > 0 else 0) }}</td></tr>{% endfor %}</tbody></table>
@@ -503,6 +508,7 @@
             {% if scorecard_data.innings2BatTeam %}
             <h4>Innings 2: {{ scorecard_data.innings2BatTeam.upper() }}</h4>
             <table><thead><tr><th>Player</th><th>Runs</th><th>Balls</th><th>SR</th><th>How Out</th></tr></thead><tbody>{% for player, stats in scorecard_data.innings2Battracker.items() %}<tr><td>{{ player }}</td><td>{{ stats.runs }}</td><td>{{ stats.balls }}</td><td>{{ '%.2f'|format((stats.runs / stats.balls * 100) if stats.balls > 0 else 0) }}</td><td>{{ stats.how_out }}</td></tr>{% endfor %}</tbody></table>
+<div data-banner-id="6077709" style="margin: 10px 0; text-align: center;"></div>
             <p><strong>Total: {{ scorecard_data.innings2Runs }}/{{ scorecard_data.innings2Wickets }} ({{ (scorecard_data.innings2Balls // 6) if scorecard_data.innings2Balls else 0 }}.{{ scorecard_data.innings2Balls % 6 if scorecard_data.innings2Balls else 0 }} Overs)</strong></p>
             <h5>Bowling: {{ scorecard_data.innings1BatTeam.upper() }}</h5>
             <table><thead><tr><th>Player</th><th>Overs</th><th>Runs</th><th>Wickets</th><th>Economy</th></tr></thead><tbody>{% for player, stats in scorecard_data.innings2Bowltracker.items() %}<tr><td>{{ player }}</td><td>{{ (stats.balls // 6) if stats.balls else 0 }}.{{ stats.balls % 6 if stats.balls else 0 }}</td><td>{{ stats.runs }}</td><td>{{ stats.wickets }}</td><td>{{ '%.2f'|format((stats.runs / (stats.balls / 6)) if stats.balls > 0 else 0) }}</td></tr>{% endfor %}</tbody></table>


### PR DESCRIPTION
This commit introduces additional ad units to increase ad density as per your request:

1.  **In-page Ad Integration (`data-admpid="338049"`):**
    *   The script for this ad type has been added to the `<head>` of both `index.html` and `ball_by_ball.html`. This ad is expected to manage its own display and placement upon loading.

2.  **"More Banner Ads" (`data-admpid="338051"`, `data-banner-id="6077709"`):**
    *   The head script for this banner type has been added to both `index.html` and `ball_by_ball.html`.
    *   **On `index.html`:** 5 instances of the banner spot `<div>` have been integrated into various locations within the main content, including areas visible during team selection and within the scorecard display.
    *   **On `ball_by_ball.html`:** 4 instances of the banner spot `<div>` have been added to the main content area, targeting new locations to complement existing banner ads.

These additions significantly increase the number of ad placements on the specified pages, fulfilling your request to add as many ads as possible in the main content areas.